### PR TITLE
Complex statement indentation fix :P

### DIFF
--- a/cfg.nim
+++ b/cfg.nim
@@ -145,7 +145,8 @@ proc save*(settings: TGlobalSettings) =
       of WrapNone: "none"
       of WrapChar: "char"
       of WrapWord: "word"
-      else: assert false; ""
+      else:
+        assert false; ""
     )
 
     f.writeKeyVal("nimrodCmd", settings.nimrodCmd)


### PR DESCRIPTION
I've got compilation error using nimrod 0.9.2:

```
cfg.nim(148, 25) Error: ')' expected
```
