### PR TITLE
fix GLib-CRITICAL assertion failures when drag selecting text

### DIFF
--- a/search.nim
+++ b/search.nim
@@ -21,12 +21,13 @@ const
                        '{', '}', '`', '[', ']', ',', ';'} +
                       strutils.Whitespace + {'\t'}
 
-proc newHighlightAll*(text: string, forSearch: bool, idleID: int32): THighlightAll =
+proc newHighlightAll*(text: string, forSearch: bool, idleID: int32,
+                      idIsInvalid: ref bool = new(bool)): THighlightAll =
   result.isHighlighted = true
   result.text = text
   result.forSearch = forSearch
-  result.idleID = new(int32)
-  result.idleID[] = idleID
+  result.idleID = idleID
+  result.idIsInvalid = idIsInvalid
 
 proc newNoHighlightAll*(): THighlightAll =
   result.isHighlighted = false
@@ -223,11 +224,12 @@ proc stopHighlightAll*(w: var MainWin, forSearch: bool) =
     if not forSearch and w.tabs[current].highlighted.forSearch: return
     
     var idleID = w.tabs[current].highlighted.idleID
+    let idIsInvalid = w.tabs[current].highlighted.idIsInvalid[]
     
-    if (idleID != nil and idleID[] != 0):
-      discard gSourceRemove(idleID[])
+    if (not idIsInvalid and idleID != 0):
+      discard gSourceRemove(idleID)
       # It is a programmer error to remove the same source twice
-      idleID[] = 0
+      idleID = 0
     
     var startIter, endIter: TTextIter
     w.tabs[current].buffer.getStartIter(addr(startIter))
@@ -261,7 +263,7 @@ proc highlightAll*(w: var MainWin, term: string, forSearch: bool, mode = SearchC
       buffer: PSourceBuffer
       term: string 
       mode: TSearchEnum
-      idleId: ref int32
+      idleIdIsInvalid: ref bool
       findIter: iterator (buffer: PSourceBuffer, 
                           term: string, mode: TSearchEnum): 
                         tuple[startMatch, endMatch: TTextIter] {.closure.}
@@ -271,6 +273,10 @@ proc highlightAll*(w: var MainWin, term: string, forSearch: bool, mode = SearchC
   idleParam.term = term
   idleParam.mode = mode
   idleParam.findIter = findTerm
+  # note: we must create a new bool each time so that idleHighlightAllRemove
+  # doesn't clobber the current value in w.tabs[current].highlighted, i.e it 
+  # just clobbers a stale reference
+  idleParam.idleIdIsInvalid = new(bool)
   GCRef(idleParam) # Make sure `idleParam` is not deallocated by the GC.
   
   discard w.tabs[current].buffer.createTag(HighlightTagName,
@@ -288,16 +294,14 @@ proc highlightAll*(w: var MainWin, term: string, forSearch: bool, mode = SearchC
     let idleParam = cast[ref TIdleParam](param)
     # When this function is called the idleID is no longer valid as it signals
     # that the idle function has already been removed from the main loop
-    if idleParam.idleID != nil:
-      idleParam.idleID[] = 0
+    idleParam.idleIdIsInvalid[] = true
     GCUnref(idleParam)
     GC_fullCollect()
   
   let idleID =
       gIdleAddFull(GPRIORITY_DEFAULT_IDLE, idleHighlightAll,
                    cast[ptr TIdleParam](idleParam), idleHighlightAllRemove)
-  w.tabs[current].highlighted = newHighlightAll(term, forSearch, idleID)
-  idleParam.idleID = w.tabs[current].highlighted.idleID
+  w.tabs[current].highlighted = newHighlightAll(term, forSearch, idleID, idleParam.idleIdIsInvalid)
 
 proc findText*(forward: bool) =
   # This proc gets called when the 'Next' or 'Prev' buttons

--- a/utils.nim
+++ b/utils.nim
@@ -236,7 +236,7 @@ type
     isHighlighted*: bool
     text*: string # What is currently being highlighted in this tab
     forSearch*: bool # Whether highlightedText is done as a result of a search.
-    idleID*: int32
+    idleID*: ref int32
 
 # -- Debug
 proc echod*(s: varargs[string, `$`]) =

--- a/utils.nim
+++ b/utils.nim
@@ -236,7 +236,8 @@ type
     isHighlighted*: bool
     text*: string # What is currently being highlighted in this tab
     forSearch*: bool # Whether highlightedText is done as a result of a search.
-    idleID*: ref int32
+    idleID*: int32
+    idIsInvalid*: ref bool
 
 # -- Debug
 proc echod*(s: varargs[string, `$`]) =


### PR DESCRIPTION
The issue was that you got a bunch of these:

```
(aporia:6351): GLib-CRITICAL **: Source ID 18373 was not found when attempting to remove it
```

when drag selecting text. Here is an attempted fix, any comments welcomed.