### PR TITLE
Unify and improve "scroll-to" functions

### DIFF
--- a/aporia.nim
+++ b/aporia.nim
@@ -1661,17 +1661,23 @@ proc goLine_Changed(ed: PEditable, d: Pgpointer) =
     if not (lineNum-1 < 0 or (lineNum > buffer.getLineCount())):
       var iter: TTextIter
       buffer.getIterAtLine(addr(iter), int32(lineNum)-1)
-      
+
       buffer.moveMarkByName("insert", addr(iter))
       buffer.moveMarkByName("selection_bound", addr(iter))
       discard PTextView(win.tabs[current].sourceView).
           scrollToIter(addr(iter), 0.2, false, 0.0, 0.0)
-      
+
+      # Select line to make it better noticeable
+      var colEndAtLine: TTextIter
+      buffer.getIterAtLine(addr(colEndAtLine), int32(lineNum)-1)
+      moveToEndLine(addr(colEndAtLine))
+      buffer.selectRange(addr(iter), addr(colEndAtLine))  
+
       # Reset entry color.
       win.goLineBar.entry.modifyBase(STATE_NORMAL, nil)
       win.goLineBar.entry.modifyText(STATE_NORMAL, nil)
       return # Success
-  
+
   # Make entry red.
   var red: gdk2.TColor
   discard colorParse("#ff6666", addr(red))

--- a/aporia.nim
+++ b/aporia.nim
@@ -1638,6 +1638,13 @@ proc goLine_Changed(ed: PEditable, d: Pgpointer) =
   win.goLineBar.entry.modifyBase(STATE_NORMAL, addr(red))
   win.goLineBar.entry.modifyText(STATE_NORMAL, addr(white))
 
+# Return pressed
+proc goLine_EnterPressed(ed: PEditable, d: Pgpointer) =
+  var line = win.goLineBar.entry.getText()
+  var lineNum: BiggestInt = -1
+  if parseBiggestInt($line, lineNum) != 0:
+    discard win.goToLine(lineNum - 1, 0, true)
+
 proc goLineClose_clicked(button: PButton, user_data: Pgpointer) = 
   win.goLineBar.bar.hide()
 
@@ -2212,10 +2219,10 @@ proc initGoLineBar(MainBox: PBox) =
   win.goLineBar.entry = entryNew()
   win.goLineBar.bar.packStart(win.goLineBar.entry, false, false, 0)
   discard win.goLineBar.entry.signalConnect("changed", SIGNAL_FUNC(
-                                      goLine_changed), nil)
+                                      goLine_Changed), nil)
   # Go to line also when Return key is pressed:                                    
   discard win.goLineBar.entry.signalConnect("activate", SIGNAL_FUNC(
-                                      goLine_changed), nil)
+                                      goLine_EnterPressed), nil)
   win.goLineBar.entry.show()
   
   # Right side ...

--- a/cfg.nim
+++ b/cfg.nim
@@ -34,6 +34,7 @@ proc defaultGlobalSettings*(): TGlobalSettings =
   result.indentWidth = 2
   result.showLineNumbers = true
   result.highlightMatchingBrackets = true
+  result.highlightCurrentLine = true
   result.toolBarVisible = true
   result.autoIndent = true
   result.compileSaveAll = false

--- a/utils.nim
+++ b/utils.nim
@@ -356,16 +356,12 @@ proc moveToEndLine*(iter: PTextIter) =
 proc goToLine*(win: var MainWin, line: BiggestInt = 0, column = 0, focus = false): bool =
   var current = win.sourceViewTabs.getCurrentPage()
   template buffer: expr = win.tabs[current].buffer
-  if line-1 < 0 or line > buffer.getLineCount():
+  if line < 0 or line >= buffer.getLineCount():
     return false
   var iter: TTextIter
   buffer.getIterAtLineOffset(addr(iter), line.gint, column.gint)
-
-  # Select line to make it better noticeable
-  var endOfLine = iter
-  moveToEndLine(addr(endOfLine))
-  buffer.selectRange(addr(iter), addr(endOfLine))
-  
+  buffer.moveMarkByName("insert", addr(iter))
+  buffer.moveMarkByName("selection_bound", addr(iter))
   win.forceScrollToInsert(-1, focus)
   result = true
   


### PR DESCRIPTION
Changes:
* Use forceScrollToInsert() instead of scrollToInsert()
* Added goToLine() to scroll to a given line and column, and optional grab the focus
* The focus will be grabed in forceScrollToInsert() (old impementation did not work)
* When pressing Enter on GoToLine edit box, the source view will be focused
* Set globalSettings.highlightCurrentLine = true by default