### PR TITLE
Improve search wrap handling

### DIFF
--- a/cfg.nim
+++ b/cfg.nim
@@ -19,7 +19,6 @@ type
 
 proc defaultAutoSettings*(): TAutoSettings =
   result.search = SearchCaseInsens
-  result.wrapAround = true
   result.winWidth = 800
   result.winHeight = 600
 
@@ -50,6 +49,7 @@ proc defaultGlobalSettings*(): TGlobalSettings =
   result.singleInstance = true
   result.restoreTabs = true
   result.activateErrorTabOnErrors = false
+  result.alwaysWrapSearch = true
   result.keyCommentLines      = TShortcutKey(keyval: KEY_slash, state: ControlMask)
   result.keyDeleteLine        = TShortcutKey(keyval: KEY_d, state: ControlMask)
   result.keyDuplicateLines    = TShortcutKey(keyval: 0, state: 0)
@@ -114,7 +114,6 @@ proc save(settings: TAutoSettings, win: var MainWin) =
     f.write(confInfo & "\n")
     
     f.writeKeyVal("searchMethod", $int(settings.search))
-    f.writeKeyVal("wrapAround", $settings.wrapAround)
     f.writeKeyVal("winMaximized", $settings.winMaximized)
     f.writeKeyVal("VPanedPos", settings.VPanedPos)
     f.writeKeyVal("winWidth", settings.winWidth)
@@ -176,6 +175,7 @@ proc save*(settings: TGlobalSettings) =
     f.writeKeyVal("compileUnsavedSave", $settings.compileUnsavedSave)
     f.writeKeyVal("restoreTabs", $settings.restoreTabs)
     f.writeKeyVal("activateErrorTabOnErrors", $settings.activateErrorTabOnErrors)
+    f.writeKeyVal("alwaysWrapSearch", $settings.alwaysWrapSearch)
     f.writeKeyValRaw("nimrodPath", $settings.nimrodPath)
     f.writeKeyVal("toolBarVisible", $settings.toolBarVisible)
     f.writeKeyVal("wrapMode",
@@ -323,7 +323,6 @@ proc loadAuto(cfgErrors: var seq[TError], lastSession: var seq[string]): TAutoSe
     of cfgKeyValuePair:
       case normalize(e.key):
       of "searchmethod": result.search = TSearchEnum(e.value.parseInt())
-      of "wraparound": result.wrapAround = isTrue(e.value)
       of "winmaximized": result.winMaximized = isTrue(e.value)
       of "vpanedpos": result.VPanedPos = int32(e.value.parseInt())
       of "bottompanelvisible": result.bottomPanelVisible = isTrue(e.value)
@@ -384,6 +383,7 @@ proc loadGlobal*(cfgErrors: var seq[TError], input: PStream): TGlobalSettings =
         result.singleInstancePort = int32(e.value.parseInt())
       of "restoretabs": result.restoreTabs = isTrue(e.value)
       of "activateerrortabonerrors": result.activateErrorTabOnErrors = isTrue(e.value)
+      of "alwayswrapsearch": result.alwaysWrapSearch = isTrue(e.value)
       of "toolbarvisible": result.toolBarVisible = isTrue(e.value)
       of "compilesaveall": result.compileSaveAll = isTrue(e.value)
       of "nimrodcmd": result.nimrodCmd = e.value

--- a/search.nim
+++ b/search.nim
@@ -95,6 +95,8 @@ proc findBoundsGen(text, pattern: string,
   if result[0] == -1 or result[1] == -1: return (-1, 0)
 
 proc findConfirmWrap(forward: bool): bool = 
+  if win.globalSettings.alwaysWrapSearch:
+    return true
   var answer = 0
   if forward:
     answer = win.showYesCancelDialog("Match not found. Restart at the beginning?")
@@ -152,7 +154,7 @@ proc findRePeg(forward: bool, startIter: PTextIter,
           
     return (startMatch, endMatch, true)
   else:
-    if win.autoSettings.wrapAround and not wrappedAround:
+    if not wrappedAround:
       if forward:
         # We are at the end. Restart at the beginning.
         buffer.getStartIter(addr(startMatch))
@@ -181,7 +183,7 @@ proc findSimple(forward: bool, startIter: PTextIter,
         options, addr(startMatch), addr(endMatch), nil)
 
   if not matchFound:
-    if win.autoSettings.wrapAround and not wrappedAround:
+    if not wrappedAround:
       if forward:
         # We are at the end. Restart from beginning.
         buffer.getStartIter(addr(startMatch))

--- a/search.nim
+++ b/search.nim
@@ -94,6 +94,14 @@ proc findBoundsGen(text, pattern: string,
 
   if result[0] == -1 or result[1] == -1: return (-1, 0)
 
+proc findConfirmWrap(forward: bool): bool = 
+  var answer = 0
+  if forward:
+    answer = win.showYesCancelDialog("Match not found. Restart at the beginning?")
+  else:
+    answer = win.showYesCancelDialog("Match not found. Restart from end?")
+  result = answer == RESPONSE_ACCEPT 
+  
 proc findRePeg(forward: bool, startIter: PTextIter,
                buffer: PTextBuffer, pattern: string, mode: TSearchEnum,
                wrappedAround = false): 
@@ -151,8 +159,11 @@ proc findRePeg(forward: bool, startIter: PTextIter,
       else:
         # We are at the beginning. Restart from the end.
         buffer.getEndIter(addr(startMatch))
-      return findRePeg(forward, addr(startMatch), buffer, pattern, mode, true)
-  
+      var res = findRePeg(forward, addr(startMatch), buffer, pattern, mode, true)
+      # Only wrap search when the match is new one AND user wants to wrap
+      if compare(addr(res.endMatch), startIter) != 0 and findConfirmWrap(forward):
+        return res
+          
     return (startMatch, endMatch, false)
 
 proc findSimple(forward: bool, startIter: PTextIter,
@@ -177,7 +188,10 @@ proc findSimple(forward: bool, startIter: PTextIter,
       else:
         # We are at the beginning. Restart from end.
         buffer.getEndIter(addr(startMatch))
-      return findSimple(forward, addr(startMatch), buffer, pattern, mode, true)
+      var res = findSimple(forward, addr(startMatch), buffer, pattern, mode, true)
+      # Only wrap search when the match is new one AND user wants to wrap
+      if compare(addr(res.endMatch), startIter) != 0 and findConfirmWrap(forward):
+        return res
     
   return (startMatch, endMatch, matchFound.bool)
 

--- a/settings.nim
+++ b/settings.nim
@@ -285,6 +285,9 @@ proc autoIndent_Toggled(button: PToggleButton, user_data: Pgpointer) =
 proc suggestFeature_Toggled(button: PToggleButton, user_data: Pgpointer) =
   win.globalSettings.suggestFeature = button.getActive()
 
+proc alwaysWrapSearch_Toggled(button: PToggleButton, user_data: Pgpointer) =
+  win.globalSettings.alwaysWrapSearch = button.getActive()
+  
 proc showCloseOnAllTabs_Toggled(button: PToggleButton, user_data: Pgpointer) =
   win.globalSettings.showCloseOnAllTabs = button.getActive()
   # Loop through each tab, and change the setting.
@@ -390,6 +393,18 @@ proc initEditor(settingsTabs: PNotebook) =
     G_CALLBACK(suggestFeature_Toggled), nil)
   suggestFeatureHBox.packStart(suggestFeatureCheckBox, false, false, 20)
   suggestFeatureCheckBox.show()
+  
+  # Search alwaysWrapSearch - checkbox
+  var alwaysWrapSearchHBox = hboxNew(false, 0)
+  editorVBox.packStart(alwaysWrapSearchHBox, false, false, 0)
+  alwaysWrapSearchHBox.show()
+  
+  var alwaysWrapSearchCheckBox = checkButtonNew("Always wrap around on search")
+  alwaysWrapSearchCheckBox.setActive(win.globalSettings.alwaysWrapSearch)
+  discard alwaysWrapSearchCheckBox.gSignalConnect("toggled", 
+    G_CALLBACK(alwaysWrapSearch_Toggled), nil)
+  alwaysWrapSearchHBox.packStart(alwaysWrapSearchCheckBox, false, false, 20)
+  alwaysWrapSearchCheckBox.show()
 
 var
   dialog: gtk2.PWindow

--- a/utils.nim
+++ b/utils.nim
@@ -575,6 +575,15 @@ proc setHighlightSyntax*(win: var MainWin, tab: int, doHighlight: bool) =
   win.tabs[tab].buffer.setHighlightSyntax(doHighlight)
   win.tempStuff.commentSyntax = ("", "", "")
 
+proc showYesCancelDialog*(win: ptr MainWin, text: string): int =
+  var dialog = win.w.messageDialogNew(0, MessageWarning, BUTTONS_NONE, nil)
+  dialog.setTransientFor(win.w)
+  dialog.setMarkup(text)
+  dialog.addButtons(STOCK_YES, ResponseAccept, STOCK_CANCEL, ResponseCancel, 
+     nil)
+  result = dialog.run()
+  gtk2.destroy(PWidget(dialog))
+  
 # -- Compilation-specific
 
 proc getCmd*(win: var MainWin, cmd, filename: string): string =

--- a/utils.nim
+++ b/utils.nim
@@ -18,7 +18,6 @@ import AboutDialog, ShortcutUtils
 type
   TAutoSettings* = object # Settings which should not be set by the user manually
     search*: TSearchEnum # Search mode.
-    wrapAround*: bool # Whether to wrap the search around.
     
     winMaximized*: bool # Whether the MainWindow is maximized on startup
     VPanedPos*: int32 # Position of the VPaned, which splits
@@ -59,6 +58,7 @@ type
     singleInstance*: bool # Whether the program runs as single instance.
     restoreTabs*: bool    # Whether the program loads the tabs from the last session
     activateErrorTabOnErrors*: bool    # Whether the Error list tab will be shown when an error ocurs
+    alwaysWrapSearch*: bool    # true: search will wrap around, false: user will be asked whether to wrap around
     keyCommentLines*:      TShortcutKey
     keyDeleteLine*:        TShortcutKey 
     keyDuplicateLines*:    TShortcutKey 


### PR DESCRIPTION
* Removed auto setting wrapAround (was never set to false) 
* Add global setting alwaysWrapSearch (default: true) 
  * When true: search will wrap around. 
  * When false: user will be asked whether to wrap around 
  * Can be changed in the settings dialog.
* Do not wrap around when there is only one match