### PR TITLE
Added gtk2 nimble package to the require dependencies list

### DIFF
--- a/readme.markdown
+++ b/readme.markdown
@@ -24,7 +24,7 @@ Aporia.
 * GTK
 * GtkSourceView
 * PCRE
-* gtk2 nimble package (if you're not installing through nimble)
+* `gtk2` nimble package (if you're not installing through nimble)
 
 Installation instructions:
 

--- a/readme.markdown
+++ b/readme.markdown
@@ -24,6 +24,7 @@ Aporia.
 * GTK
 * GtkSourceView
 * PCRE
+* gtk2 nimble package (if you're not installing through nimble)
 
 Installation instructions:
 


### PR DESCRIPTION
Installing through nimble automates this process so unless you're looking for it, you wouldn't know you needed the gtk2 dependency because aporia successfully compiles without error, but the exe errors out without that package installed.