### PR TITLE
Nim diagnostics column numbers now start from 1

### DIFF
--- a/processes.nim
+++ b/processes.nim
@@ -116,7 +116,9 @@ proc parseError(err: string, res: var TError) =
   res.column = ""
   var colInt = -1
   i += parseInt(err, colInt, i)
-  res.column = $colInt
+  # NOTE: Aporia numbers colums from 0,
+  # but Nim diagnostics column numbers start from 1
+  res.column = $(max(0, colInt-1))
   inc(i) # Skip )
   i += skipWhitespace(err, i)
   var theType = ""


### PR DESCRIPTION
Nim recently switched to numbering error diagnostics columns from 1.
Aporia however still expects column to start from 0, unlike other editors/IDEs.