### PR TITLE
Resolves issue-102

### DIFF
--- a/processes.nim
+++ b/processes.nim
@@ -22,6 +22,7 @@ var
   pegLineError = peg"{[^(]*} '(' {\d+} ', ' \d+ ') Error:' \s* {.*}"
   pegLineWarning = peg"{[^(]*} '(' {\d+} ', ' \d+ ') ' ('Warning:'/'Hint:') \s* {.*}"
   pegOtherError = peg"'Error:' \s* {.*}"
+  pegSegFault = peg"'SIGSEGV:' \s* {.*}"
   pegSuccess = peg"'Hint: operation successful'.*"
   pegOtherHint = peg"'Hint: '.*"
   reLineMessage = re".+\(\d+,\s\d+\)"
@@ -167,6 +168,9 @@ proc printProcOutput(win: var MainWin, line: string) =
     elif line =~ pegLineWarning:
       win.outputTextView.addText(line & "\l", warningTag)
       paErr()
+    elif line =~ pegSegFault:
+      win.outputTextView.addText(line & "\l", errorTag)    
+      win.tempStuff.compileSuccess = false      
     else:
       win.outputTextView.addText(line & "\l", normalTag)
   of ExecRun, ExecCustom:


### PR DESCRIPTION
The SEGFAULT string generated by the compiler was falling through the
success check in execProcAsync. Add a new string and to match SIGSEGV and add corresponding elif to mark compileSuccess as false.

This is tested Debian 8.

Create a simple binary:

    echo "old bin"

Run "Compile and run current file" through Aporia

Now add some segfaulty stuff. This is a snippet from Nim issue 4003:

    echo "new bin"

    proc boo(p: proc)

    proc quux(p: proc) =
        discard

    proc boo(p: proc) =
      discard


Prior to this patch, executing "Compile and run current file" would show a segfault message and then run the old bin resulting in "old bin" printing in the output window. The patched version shows the segfault message and quits.

Fixed #102 