### PR TITLE
Fixed #109.

### DIFF
--- a/aporia.nim
+++ b/aporia.nim
@@ -990,6 +990,7 @@ proc closeCurrentTab_Activate(menuItem: PMenuItem, user_data: pointer) =
 proc closeAllTabs_Activate(menuItem: PMenuItem, user_data: pointer) =
   while win.tabs.len() > 0:
     closeTab(win.sourceViewTabs.getCurrentPage())
+  discard addTab("", "", true)
 
 proc recentFile_Activate(menuItem: PMenuItem, file: gpointer) =
   let filename = cast[string](file)

--- a/aporia.nim
+++ b/aporia.nim
@@ -375,7 +375,8 @@ proc window_keyPress(widg: PWidget, event: PEventKey,
       return true
     of KeyW:
       # Ctrl + W
-      closeTab(win.sourceViewTabs.getCurrentPage())
+      if win.sourceViewTabs.getNPages() > 1:
+        closeTab(win.sourceViewTabs.getCurrentPage())
       return true
     else:
       discard


### PR DESCRIPTION
The last tab can no longer be closed with Control-W.

In addition, Close All will now open an empty tab after closing all existing ones.