### PR TITLE
Fixed #114.

### DIFF
--- a/aporia.nim
+++ b/aporia.nim
@@ -782,9 +782,6 @@ proc addTab(name, filename: string, setCurrent: bool = true,
   ## ``-1`` is returned upon error.
   assert(win.nimLang != nil)
 
-  # Save the preferences before the tab is opened.
-  win.save()
-
   var buffer: PSourceBuffer = sourceBufferNew(win.nimLang)
 
   if filename != nil and filename != "":
@@ -894,6 +891,9 @@ proc addTab(name, filename: string, setCurrent: bool = true,
   if setCurrent:
     # Select the newly created tab
     win.sourceViewTabs.setCurrentPage(int32(win.tabs.len())-1)
+  
+  win.save()
+
   return win.tabs.len()-1
 
 # GTK Events Contd.
@@ -2084,11 +2084,7 @@ proc initsourceViewTabs() =
   if win.globalSettings.restoreTabs and lastSession.len > 0:
     for i in 0 .. lastSession.len-1:
       var splitUp = lastSession[i].split('|')
-      var filename, offset: string
-      if len(splitUp) == 2:
-        (filename, offset) = (splitUp[0], splitUp[1])
-      else:
-        (filename, offset) = ("", "0")
+      var (filename, offset) = (splitUp[0], splitUp[1])
       if existsFile(filename):
         let newTab = addTab("", filename, win.autoSettings.lastSelectedTab == filename)
         inc(count)

--- a/aporia.nim
+++ b/aporia.nim
@@ -360,6 +360,7 @@ proc closeTab(tab: int) =
       recentlyOpenedAdd(win.tabs[tab].filename)
     system.delete(win.tabs, tab)
     win.sourceViewTabs.removePage(int32(tab))
+    win.save()
 
 proc window_keyPress(widg: PWidget, event: PEventKey,
                           userData: Pgpointer): gboolean =
@@ -780,6 +781,9 @@ proc addTab(name, filename: string, setCurrent: bool = true,
   ## Returns the index of the added tab (or existing tab if setCurrent is true).
   ## ``-1`` is returned upon error.
   assert(win.nimLang != nil)
+
+  # Save the preferences before the tab is opened.
+  win.save()
 
   var buffer: PSourceBuffer = sourceBufferNew(win.nimLang)
 
@@ -2080,7 +2084,11 @@ proc initsourceViewTabs() =
   if win.globalSettings.restoreTabs and lastSession.len > 0:
     for i in 0 .. lastSession.len-1:
       var splitUp = lastSession[i].split('|')
-      var (filename, offset) = (splitUp[0], splitUp[1])
+      var filename, offset: string
+      if len(splitUp) == 2:
+        (filename, offset) = (splitUp[0], splitUp[1])
+      else:
+        (filename, offset) = ("", "0")
       if existsFile(filename):
         let newTab = addTab("", filename, win.autoSettings.lastSelectedTab == filename)
         inc(count)

--- a/settings.nim
+++ b/settings.nim
@@ -441,7 +441,7 @@ proc closeDialog(widget: PWidget, user_data: Pgpointer) =
   win.globalSettings.customCmd3 = $custom3Edit.getText()
   
   # Save the preferences.
-  cast[ptr utils.MainWin](win)[].save()
+  win[].save()
   
   gtk2.PObject(dialog).destroy()
   

--- a/settings.nim
+++ b/settings.nim
@@ -440,6 +440,9 @@ proc closeDialog(widget: PWidget, user_data: Pgpointer) =
   win.globalSettings.customCmd2 = $custom2Edit.getText()
   win.globalSettings.customCmd3 = $custom3Edit.getText()
   
+  # Save the preferences.
+  cast[ptr utils.MainWin](win)[].save()
+  
   gtk2.PObject(dialog).destroy()
   
 proc addCheckBox(parent: PVBox, labelText: string, value: bool): PCheckButton =
@@ -591,7 +594,7 @@ proc initShortcuts(settingsTabs: PNotebook) =
           
 proc showSettings*(aWin: var utils.MainWin) =
   win = addr(aWin)  # This has to be a pointer
-                    # Because i need the settings to be changed
+                    # Because I need the settings to be changed
                     # in aporia.nim not in here.
 
   dialog = windowNew(gtk2.WINDOW_TOPLEVEL)


### PR DESCRIPTION
Added win.save() calls to addTab() and closeTab().

The call in addTab() ensures that #114 is fixed, the call in closeTab() is to ensure the tabs are saved after a crash.