### PR TITLE
Check if the file has been modified outside Aporia

### DIFF
--- a/aporia.nim
+++ b/aporia.nim
@@ -129,7 +129,7 @@ proc updateTabUI(t: Tab) =
 proc saveTab(tabNr: int, startpath: string, updateGUI: bool = true) =
   ## If tab's filename is ``""`` and the user clicks "Cancel", the filename will
   ## remain ``""``.
-
+  
   # TODO: Refactor this function. It's a disgrace.
   if tabNr < 0: return
   if win.tabs[tabNr].saved: return
@@ -1810,12 +1810,19 @@ proc initTopMenu(mainBox: PBox) =
       discard addTab("", joinPath(os.getConfigDir(), "Aporia", "config.global.ini"))
     except EIO:
       win.statusBar.setTemp(getCurrentExceptionMsg(), UrgError)
+  
+  proc reloadPreferences_onActivate(i: PMenuItem, p: pointer) {.cdecl.} =
+    var cfgErrors: seq[TError] = @[]
+    let (auto, global) = cfg.load(cfgErrors, lastSession)
+    win.globalSettings = global
 
   when not defined(macosx):
-    # Raw preferences
-    EditMenu.createMenuItem("Raw Preferences", rawPreferences_onActivate)
     # Preferences
     EditMenu.createImageMenuItem(StockPreferences, aporia.settings_Activate)
+    # Raw preferences
+    EditMenu.createMenuItem("Raw Preferences", rawPreferences_onActivate)
+    # Reload preferences
+    EditMenu.createMenuItem("Reload Preferences", reloadPreferences_onActivate)
 
   var EditMenuItem = menuItemNewWithMnemonic("_Edit")
   EditMenuItem.setSubMenu(EditMenu)

--- a/search.nim
+++ b/search.nim
@@ -124,6 +124,8 @@ proc findRePeg(win: var utils.MainWin, forward: bool, startIter: PTextIter,
     # Yeah. I know inefficient, but that's the only way I know how to do this.
     var newMatch = (-1, 0)
     while true:
+      # This stops Aporia from getting stuck on the same character, as otherwise the
+      # starting position will not change.
       if match[0] == match[1]:
         inc(match[1])
         singleChar = true
@@ -131,7 +133,7 @@ proc findRePeg(win: var utils.MainWin, forward: bool, startIter: PTextIter,
       if newMatch != (-1, 0): match = newMatch
       else: break
 
-  if singleChar:
+  if not forward and singleChar:
     dec(match[1])
 
   var startMatch, endMatch: TTextIter

--- a/search.nim
+++ b/search.nim
@@ -116,6 +116,7 @@ proc findRePeg(win: var utils.MainWin, forward: bool, startIter: PTextIter,
     
   var matches: array[0..re.MaxSubpatterns, string]
   var match = (-1, 0)
+  var singleChar = false
   if forward:
     match = findBoundsGen($text, newPattern, isRegex, reOptions)
   else: # Backward search.
@@ -123,9 +124,15 @@ proc findRePeg(win: var utils.MainWin, forward: bool, startIter: PTextIter,
     # Yeah. I know inefficient, but that's the only way I know how to do this.
     var newMatch = (-1, 0)
     while true:
+      if match[0] == match[1]:
+        inc(match[1])
+        singleChar = true
       newMatch = findBoundsGen($text, newPattern, isRegex, reOptions, match[1])
       if newMatch != (-1, 0): match = newMatch
       else: break
+
+  if singleChar:
+    dec(match[1])
 
   var startMatch, endMatch: TTextIter
   

--- a/utils.nim
+++ b/utils.nim
@@ -8,7 +8,7 @@
 #
 
 # Stdlib imports:
-import gtk2, gtksourceview, glib2, pango, osproc, streams, asyncio, strutils
+import gtk2, gtksourceview, glib2, pango, osproc, streams, asyncio, strutils, times
 import tables, os, dialogs, pegs
 from gdk2 import TRectangle, intersect, TColor, colorParse, TModifierType
 # Local imports:
@@ -213,6 +213,7 @@ type
     highlighted*: THighlightAll
     spbInfo*: tuple[lastUpper, value: float] # Scroll past bottom info
     lineEnding*: TLineEnding
+    lastEdit*: Time
 
   TSuggestItem* = object
     nodeType*, name*, nimType*, file*, nmName*, docs*: string


### PR DESCRIPTION
This checks if a file has been modified outside Aporia since the user last saved, and if so offers to either reload the modified file or ignore and keep the version currently open in Aporia. It uses last modified timestamps, so there should be very little overhead. Currently it checks this on tab switch or tab save.