### PR TITLE
Renamed types to fit newer conventions

### DIFF
--- a/AboutDialog.nim
+++ b/AboutDialog.nim
@@ -2,19 +2,17 @@ import gtk2
 from gdk2 import WINDOW_TYPE_HINT_MENU
 
 type
-  TAboutDialog* = object
+  AboutDialog* = ref object
     dialog: PWindow
     titleLabel: PLabel
     descLabel: PLabel
     copyrightLabel: PLabel
 
-  PAboutDialog* = ref TAboutDialog
-
 proc closeBtn_click(btn: PButton, dummy: pointer) {.cdecl.} =
   # Kinda hackish.
   btn.parent.parent.parent.destroy()
 
-proc newAboutDialog*(title, desc, copyright: string): PAboutDialog =
+proc newAboutDialog*(title, desc, copyright: string): AboutDialog =
   new(result)
   result.dialog = windowNew(WINDOW_TOPLEVEL)
   result.dialog.setTitle("About Aporia")
@@ -53,5 +51,5 @@ proc newAboutDialog*(title, desc, copyright: string): PAboutDialog =
   discard closeBtn.signalConnect("clicked", 
       SIGNAL_FUNC(closeBtn_click), nil)
 
-proc show*(about: PAboutDialog) =
+proc show*(about: AboutDialog) =
   about.dialog.show()

--- a/aporia.nim
+++ b/aporia.nim
@@ -53,12 +53,13 @@ proc parseArgs(): seq[string] =
       case key
       of "help", "h": writeHelp()
       of "version", "v": writeVersion()
+      else: discard
     of cmdEnd: assert(false) # cannot happen
 
 var loadFiles = parseArgs()
 
 # Load the settings
-var cfgErrors: seq[TError] = @[]
+var cfgErrors: seq[AporiaError] = @[]
 let (auto, global) = cfg.load(cfgErrors, lastSession)
 win.autoSettings = auto
 win.globalSettings = global
@@ -532,6 +533,8 @@ proc sourceViewKeyPress(sourceView: PWidget, event: PEventKey,
         of "page_down":
           moved = true
           nextTimes(5)
+        else:
+          discard
 
         if moved:
           # selectedPath is now the next or prev path.
@@ -645,7 +648,7 @@ proc goToDef_Activate(i: PMenuItem, p: pointer) {.cdecl.} =
   tab.buffer.getIterAtMark(addr(cursor), tab.buffer.getInsert())
 
   proc onSugLine(win: var MainWin, line: string) {.closure.} =
-    var def: TSuggestItem
+    var def: SuggestItem
     if parseIDEToolsLine("def", line, def):
       win.tempStuff.gotDefinition = true
       let existingTab = win.findTab(def.file, true)
@@ -1296,7 +1299,7 @@ proc compileRun(filename: string, shouldRun: bool) =
 
   # Execute the compiled application if compiled successfully.
   # ifSuccess is the filename of the compiled app.
-  var runAfter: PExecOptions = nil
+  var runAfter: ExecOptions = nil
   let workDir = filename.splitFile.dir
   if shouldRun:
     let ifSuccess = changeFileExt(filename, os.ExeExt)
@@ -1416,7 +1419,7 @@ proc InfoBar_Response(infobar: PInfoBar, respID: gint, cb: pointer) =
     comboBox.setActive(0) # Reset selection.
     infobar.hide()
     discard addTab("", win.tempStuff.pendingFilename, true,
-           $TEncodingsAvailable(active))
+           $EncodingsAvailable(active))
     # addTab may set pendingFilename so we can't reset it here.
     # bad things shouldn't happen if it doesn't get reset though.
   of ResponseCancel:

--- a/autocomplete.nim
+++ b/autocomplete.nim
@@ -162,6 +162,8 @@ proc peekSuggestOutput(self: AutoComplete): gboolean {.cdecl.} =
       return false
     of errorToken:
       self.onSugError(msg.split("\t")[1])
+    else:
+      discard
     self.onSugLine(msg)
 
   if not result:

--- a/processes.nim
+++ b/processes.nim
@@ -12,9 +12,9 @@ import gtk2, glib2
 import utils, CustomStatusBar
 
 # Threading channels
-var execThrTaskChan: Channel[TExecThrTask]
+var execThrTaskChan: Channel[ExecThrTask]
 execThrTaskChan.open()
-var execThrEventChan: Channel[TExecThrEvent]
+var execThrEventChan: Channel[ExecThrEvent]
 execThrEventChan.open()
 # Threading channels END
 
@@ -27,7 +27,7 @@ var
   reLineMessage = re".+\(\d+,\s\d+\)"
   pegLineInfo = peg"{[^(]*} '(' {\d+} ', ' \d+ ') Info:' \s* {.*}"
 
-proc `$`(theType: TErrorType): string =
+proc `$`(theType: ErrorType): string =
   case theType
   of TETError: result = "Error"
   of TETWarning: result = "Warning"
@@ -38,7 +38,7 @@ proc clearErrors*(win: var MainWin) =
   cast[PListStore](TreeModel).clear()
   win.tempStuff.errorList = @[]
 
-proc addError*(win: var MainWin, error: TError) =
+proc addError*(win: var MainWin, error: AporiaError) =
   # Make the file path a bit shorter, so it's more readable
   var fileShort = error.file
   var mainDir = win.tabs[win.sourceViewTabs.getCurrentPage()].filename
@@ -65,7 +65,7 @@ proc addError*(win: var MainWin, error: TError) =
 
   win.tempStuff.errorList.add(error)
 
-proc parseError(err: string, res: var TError) =
+proc parseError(err: string, res: var AporiaError) =
   ## Parses a line like:
   ##   ``a12.nim(1, 3) Error: undeclared identifier: 'asd'``
   ##
@@ -135,14 +135,14 @@ proc parseError(err: string, res: var TError) =
   i += skipWhitespace(err, i)
   res.desc = err.substr(i, err.len()-1)
 
-proc execProcAsync*(win: var MainWin, exec: PExecOptions)
+proc execProcAsync*(win: var MainWin, exec: ExecOptions)
 proc printProcOutput(win: var MainWin, line: string) =
   ## This shouldn't have to worry about receiving broken up errors (into new lines)
   ## continuous errors should be received, errors which span multiple lines
   ## should be received as one continuous message.
   echod("Printing: ", line.repr)
   template paErr(): typed =
-    var parseRes: TError
+    var parseRes: AporiaError
     parseError(line, parseRes)
 
     win.addError(parseRes)
@@ -172,7 +172,7 @@ proc printProcOutput(win: var MainWin, line: string) =
   of ExecRun, ExecCustom:
     win.outputTextView.addText(line & "\l", normalTag)
 
-proc parseCompilerOutput(win: var MainWin, event: TExecThrEvent) =
+proc parseCompilerOutput(win: var MainWin, event: ExecThrEvent) =
   if event.line == "" or event.line.startsWith(pegSuccess) or
       event.line =~ pegOtherHint:
     #echod(1)
@@ -216,7 +216,7 @@ proc peekProcOutput*(win: ptr MainWin): gboolean {.cdecl.} =
                                    "darkgreen")
       var errorTag = createColor(win.outputTextView, "errorTag", "red")
       for i in 0..events-1:
-        var event: TExecThrEvent = execThrEventChan.recv()
+        var event: ExecThrEvent = execThrEventChan.recv()
         case event.typ
         of EvStarted:
           win.tempStuff.execProcess = event.p
@@ -270,7 +270,7 @@ proc peekProcOutput*(win: ptr MainWin): gboolean {.cdecl.} =
     echod("idle proc exiting")
     return false
 
-proc execProcAsync*(win: var MainWin, exec: PExecOptions) =
+proc execProcAsync*(win: var MainWin, exec: ExecOptions) =
   ## This function executes a process in a new thread, using only idle time
   ## to add the output of the process to the `outputTextview`.
   assert(win.tempStuff.currentExec == nil)
@@ -279,7 +279,7 @@ proc execProcAsync*(win: var MainWin, exec: PExecOptions) =
   # Execute the process
   win.tempStuff.currentExec = exec
   echod(exec.command)
-  var task: TExecThrTask
+  var task: ExecThrTask
   task.typ = ThrRun
   task.command = exec.command
   task.workDir = exec.workDir
@@ -298,10 +298,10 @@ proc execProcAsync*(win: var MainWin, exec: PExecOptions) =
   # Clear errors
   win.clearErrors()
 
-proc newExec*(command: string, workDir: string, mode: TExecMode, output = true,
-              onLine: proc (win: var MainWin, opts: PExecOptions, line: string) {.closure.} = nil,
-              onExit: proc (win: var MainWin, opts: PExecOptions, exitcode: int) {.closure.} = nil,
-              runAfter: PExecOptions = nil, runAfterSuccess = true): PExecOptions =
+proc newExec*(command: string, workDir: string, mode: ExecMode, output = true,
+              onLine: proc (win: var MainWin, opts: ExecOptions, line: string) {.closure.} = nil,
+              onExit: proc (win: var MainWin, opts: ExecOptions, exitcode: int) {.closure.} = nil,
+              runAfter: ExecOptions = nil, runAfterSuccess = true): ExecOptions =
   new(result)
   result.command = command
   result.workDir = workDir
@@ -312,9 +312,9 @@ proc newExec*(command: string, workDir: string, mode: TExecMode, output = true,
   result.runAfter = runAfter
   result.runAfterSuccess = runAfterSuccess
 
-template createExecThrEvent(t: TExecThrEventType, todo: typed): typed {.immediate.} =
+template createExecThrEvent(t: ExecThrEventType, todo: typed): typed {.immediate.} =
   ## Sends a thrEvent of type ``t``, does ``todo`` before sending.
-  var event {.inject.}: TExecThrEvent
+  var event {.inject.}: ExecThrEvent
   event.typ = t
   todo
   execThrEventChan.send(event)
@@ -329,7 +329,7 @@ proc cmdToArgs(cmd: string): tuple[bin: string, args: seq[string]] =
 
 proc dispatchTasks(tasks: int, started: var bool, p: var Process, o: var Stream) =
   for i in 0..tasks-1:
-    var task: TExecThrTask = execThrTaskChan.recv()
+    var task: ExecThrTask = execThrTaskChan.recv()
     case task.typ
     of ThrRun:
       if not started:

--- a/search.nim
+++ b/search.nim
@@ -18,13 +18,13 @@ const
                        '{', '}', '`', '[', ']', ',', ';'} +
                       strutils.Whitespace + {'\t'}
 
-proc newHighlightAll*(text: string, forSearch: bool, idleID: int32): THighlightAll =
+proc newHighlightAll*(text: string, forSearch: bool, idleID: int32): HighlightAll =
   result.isHighlighted = true
   result.text = text
   result.forSearch = forSearch
   result.idleID = idleID
 
-proc newNoHighlightAll*(): THighlightAll =
+proc newNoHighlightAll*(): HighlightAll =
   result.isHighlighted = false
   result.text = ""
 
@@ -37,7 +37,7 @@ proc canBeHighlighted(term: string): bool =
   for i in 1..term.len-1:
     if term[i] in NonHighlightChars: return false
   
-proc getSearchOptions(mode: TSearchEnum): TTextSearchFlags =
+proc getSearchOptions(mode: SearchEnum): TTextSearchFlags =
   case mode
   of SearchCaseInsens:
     result = TEXT_SEARCH_TEXT_ONLY or 
@@ -91,7 +91,7 @@ proc findBoundsGen(text, pattern: string,
   if result[0] == -1 or result[1] == -1: return (-1, 0)
 
 proc findRePeg(win: var utils.MainWin, forward: bool, startIter: PTextIter,
-               buffer: PTextBuffer, pattern: string, mode: TSearchEnum,
+               buffer: PTextBuffer, pattern: string, mode: SearchEnum,
                wrappedAround = false):
     tuple[startMatch, endMatch: TTextIter, found: bool] =
   var text: cstring
@@ -151,7 +151,7 @@ proc findRePeg(win: var utils.MainWin, forward: bool, startIter: PTextIter,
     return (startMatch, endMatch, false)
 
 proc findSimple(win: var utils.MainWin, forward: bool, startIter: PTextIter,
-                buffer: PTextBuffer, pattern: string, mode: TSearchEnum,
+                buffer: PTextBuffer, pattern: string, mode: SearchEnum,
                 wrappedAround = false):
                 tuple[startMatch, endMatch: TTextIter, found: bool] =
   var options = getSearchOptions(mode)
@@ -177,7 +177,7 @@ proc findSimple(win: var utils.MainWin, forward: bool, startIter: PTextIter,
   return (startMatch, endMatch, matchFound.bool)
 
 iterator findTerm(win: var utils.MainWin, buffer: PSourceBuffer, term: string,
-    mode: TSearchEnum): tuple[startMatch, endMatch: TTextIter] {.closure.} =
+    mode: SearchEnum): tuple[startMatch, endMatch: TTextIter] {.closure.} =
   const CurrentSearchPosName = "CurrentSearchPosMark"
   var searchPosMark = buffer.getMark(CurrentSearchPosName)
   var startIter: TTextIter
@@ -250,9 +250,9 @@ proc highlightAll*(w: var MainWin, term: string, forSearch: bool, mode = SearchC
       win: utils.MainWin
       buffer: PSourceBuffer
       term: string 
-      mode: TSearchEnum
+      mode: SearchEnum
       findIter: iterator (win: var utils.MainWin, buffer: PSourceBuffer, 
-                          term: string, mode: TSearchEnum): 
+                          term: string, mode: SearchEnum): 
                         tuple[startMatch, endMatch: TTextIter] {.closure.}
     
   var idleParam: ref TIdleParam; new(idleParam)

--- a/suggest.nim
+++ b/suggest.nim
@@ -36,7 +36,7 @@ proc addSuggestItem*(win: var MainWin, name: string, markup: string,
   listStore.append(addr(iter))
   listStore.set(addr(iter), 0, name, 1, markup, 2, color, 3, tooltipText, -1)
 
-proc addSuggestItem(win: var MainWin, item: TSuggestItem) =
+proc addSuggestItem(win: var MainWin, item: SuggestItem) =
   # TODO: Escape tooltip text for pango markup.
   var markup = "<b>$1</b>" % [escapePango(item.nmName)]
   case item.nodeType
@@ -44,6 +44,8 @@ proc addSuggestItem(win: var MainWin, item: TSuggestItem) =
     markup = "$1$2" % [escapePango(item.nmName), item.nimType.replaceWord("proc ","")]
   of "skField":
     markup = "<i>$1 - $2</i>" % [escapePango(item.nmName), item.nimType]
+  else:
+    discard
   win.addSuggestItem(item.nmName, markup, item.nimType)
 
 proc getIterGlobalCoords(iter: PTextIter, tab: Tab): tuple[x, y: int32] =
@@ -81,7 +83,7 @@ proc doMoveSuggest*(win: var MainWin) =
   tab.buffer.getIterAtMark(addr(start), tab.buffer.getInsert())
   moveSuggest(win, addr(start), tab)
 
-proc parseIDEToolsLine*(cmd, line: string, item: var TSuggestItem): bool =
+proc parseIDEToolsLine*(cmd, line: string, item: var SuggestItem): bool =
   if line.startsWith(cmd):
     var s = line.split('\t')
     assert s.len == 8
@@ -103,14 +105,14 @@ proc parseIDEToolsLine*(cmd, line: string, item: var TSuggestItem): bool =
 
     result = true
 
-proc clear*(suggest: var TSuggestDialog) =
+proc clear*(suggest: var SuggestDialog) =
   var treeModel = suggest.treeView.getModel()
   # TODO: Why do I have to cast it? Why can't I just do PListStore(treeModel)?
   cast[PListStore](treeModel).clear()
   suggest.items = @[]
   suggest.allItems = @[]
 
-proc show*(suggest: var TSuggestDialog) =
+proc show*(suggest: var SuggestDialog) =
   if not suggest.shown and suggest.items.len() > 0:
     var selection = suggest.treeview.getSelection()
     var selectedPath = tree_path_new_first()
@@ -120,7 +122,7 @@ proc show*(suggest: var TSuggestDialog) =
     suggest.shown = true
     suggest.dialog.show()
 
-proc hide*(suggest: var TSuggestDialog) =
+proc hide*(suggest: var SuggestDialog) =
   if suggest.shown:
     echod("[Suggest] Hide")
     suggest.shown = false
@@ -154,7 +156,7 @@ proc filterSuggest*(win: var MainWin) =
   # Filter the items.
   var allItems = win.suggest.allItems
   win.suggest.clear()
-  var newItems: seq[TSuggestItem] = @[]
+  var newItems: seq[SuggestItem] = @[]
   for i in items(allItems):
     if normalize(i.nmName).startsWith(normalize($text)):
       newItems.add(i)
@@ -192,7 +194,7 @@ proc asyncGetSuggest(win: var MainWin, file, projectFile, addToPath: string,
 
   proc onSugLine(line: string) {.closure.} =
     template win: untyped = winPtr[]
-    var item: TSuggestItem
+    var item: SuggestItem
     if parseIDEToolsLine("sug", line, item):
       win.suggest.allItems.add(item)
       let text = getFilter(win)
@@ -458,7 +460,7 @@ proc rstToPango(s: string): string =
   result = ""
   rstToPango(r, result)
 
-proc showTooltip*(win: var MainWin, tab: Tab, item: TSuggestItem,
+proc showTooltip*(win: var MainWin, tab: Tab, item: SuggestItem,
                   selectedPath: PTreePath) =
   var markup = "<i>" & escapePango(item.nimType) & "</i>"
   if item.docs != "":

--- a/utils.nim
+++ b/utils.nim
@@ -12,13 +12,13 @@ import gtk2, gtksourceview, glib2, pango, osproc, streams, asyncio, strutils
 import tables, os, dialogs, pegs, osproc
 from gdk2 import TRectangle, intersect, TColor, colorParse, TModifierType
 # Local imports:
-from CustomStatusBar import PCustomStatusBar, TStatusID
+from CustomStatusBar import CustomStatusBar, StatusID
 
 import AboutDialog
 
 type
-  TAutoSettings* = object # Settings which should not be set by the user manually
-    search*: TSearchEnum # Search mode.
+  AutoSettings* = object # Settings which should not be set by the user manually
+    search*: SearchEnum # Search mode.
     wrapAround*: bool # Whether to wrap the search around.
 
     winMaximized*: bool # Whether the MainWindow is maximized on startup
@@ -32,7 +32,7 @@ type
 
     bottomPanelVisible*: bool # Whether the bottom panel is shown
 
-  TGlobalSettings* = object
+  GlobalSettings* = object
     selectHighlightAll*: bool # Whether to highlight all occurrences upon selection
     searchHighlightAll*: bool # Whether to highlight all occurrences of the currently searched text
     font*: string # font used by the sourceview
@@ -97,11 +97,11 @@ type
   MainWin* = object
     # Widgets
     w*: gtk2.PWindow
-    suggest*: TSuggestDialog
+    suggest*: SuggestDialog
     nimLang*: PSourceLanguage
     scheme*: PSourceStyleScheme # color scheme the sourceview is meant to use
     sourceViewTabs*: PNotebook # Tabs which hold the sourceView
-    statusBar*: PCustomStatusBar
+    statusBar*: CustomStatusBar
 
     infobar*: PInfoBar ## For encoding selection
 
@@ -118,7 +118,7 @@ type
     replaceBtn*: PButton
     replaceAllBtn*: PButton
 
-    goLineBar*: TGoLineBar
+    goLineBar*: GoLineBar
 
     FileMenu*: PMenu
 
@@ -129,49 +129,48 @@ type
 
     tempStuff*: Temp # Just things to remember. TODO: Rename to `other' ?
 
-    autoSettings*: TAutoSettings
-    globalSettings*: TGlobalSettings
+    autoSettings*: AutoSettings
+    globalSettings*: GlobalSettings
     oneInstSock*: AsyncSocket
     IODispatcher*: Dispatcher
 
-  TSuggestDialog* = object
+  SuggestDialog* = object
     dialog*: gtk2.PWindow
     treeView*: PTreeView
-    items*: seq[TSuggestItem] ## Visible items (In the treeview)
-    allItems*: seq[TSuggestItem] ## All items found in current context.
+    items*: seq[SuggestItem] ## Visible items (In the treeview)
+    allItems*: seq[SuggestItem] ## All items found in current context.
     shown*: bool
     gotAll*: bool # Whether all suggest items have been read.
     currentFilter*: string
     tooltip*: gtk2.PWindow
     tooltipLabel*: PLabel
 
-  TExecMode* = enum
+  ExecMode* = enum
     ExecNim, ExecRun, ExecCustom
 
-  PExecOptions* = ref TExecOptions
-  TExecOptions* = object
+  ExecOptions* = ref object
     command*: string
     workDir*: string
-    mode*: TExecMode
+    mode*: ExecMode
     output*: bool
-    onLine*: proc (win: var MainWin, opts: PExecOptions, line: string) {.closure.}
-    onExit*: proc (win: var MainWin, opts: PExecOptions, exitcode: int) {.closure.}
+    onLine*: proc (win: var MainWin, opts: ExecOptions, line: string) {.closure.}
+    onExit*: proc (win: var MainWin, opts: ExecOptions, exitcode: int) {.closure.}
     runAfterSuccess*: bool # If true, ``runAfter`` will only be ran on success.
-    runAfter*: PExecOptions
+    runAfter*: ExecOptions
 
-  TExecThrTaskType* = enum
+  ExecThrTaskType* = enum
     ThrRun, ThrStop
-  TExecThrTask* = object
-    case typ*: TExecThrTaskType
+  ExecThrTask* = object
+    case typ*: ExecThrTaskType
     of ThrRun:
       command*: string
       workDir*: string
     of ThrStop: nil
 
-  TExecThrEventType* = enum
+  ExecThrEventType* = enum
     EvStarted, EvRecv, EvStopped
-  TExecThrEvent* = object
-    case typ*: TExecThrEventType
+  ExecThrEvent* = object
+    case typ*: ExecThrEventType
     of EvStarted:
       p*: Process
     of EvRecv:
@@ -183,16 +182,16 @@ type
     lastSaveDir*: string # Last saved directory/last active directory
     stopSBUpdates*: bool
 
-    currentExec*: PExecOptions # nil if nothing is being executed.
+    currentExec*: ExecOptions # nil if nothing is being executed.
     compileSuccess*: bool
     execThread*: Thread[void]
     execProcess*: Process
     idleFuncId*: int32
-    progressStatusID*: TStatusID
+    progressStatusID*: StatusID
     lastProgressPulse*: float
     errorMsgStarted*: bool
     compilationErrorBuffer*: string # holds error msg if it spans multiple lines.
-    errorList*: seq[TError]
+    errorList*: seq[AporiaError]
     gotDefinition*: bool
     autoComplete*: AutoComplete
 
@@ -210,36 +209,36 @@ type
     label*: PLabel
     closeBtn*: PButton # This is so that the close btn is only shown on selected tabs.
     filename*: string
-    highlighted*: THighlightAll
+    highlighted*: HighlightAll
     spbInfo*: tuple[lastUpper, value: float] # Scroll past bottom info
-    lineEnding*: TLineEnding
+    lineEnding*: LineEnding
 
-  TSuggestItem* = object
+  SuggestItem* = object
     nodeType*, name*, nimType*, file*, nmName*, docs*: string
     line*, col*: int32
 
-  TSearchEnum* = enum
+  SearchEnum* = enum
     SearchCaseSens, SearchCaseInsens, SearchStyleInsens, SearchRegex, SearchPeg
 
-  TGoLineBar* = object
+  GoLineBar* = object
     bar*: PHBox
     entry*: PEntry
 
-  TErrorType* = enum
+  ErrorType* = enum
     TETError, TETWarning
 
-  TError* = object
-    kind*: TErrorType
+  AporiaError* = object
+    kind*: ErrorType
     desc*, file*, line*, column*: string
 
-  TEncodingsAvailable* = enum
+  EncodingsAvailable* = enum
     UTF8 = "UTF-8", ISO88591 = "ISO-8859-1", GB2312 = "GB2312",
     Windows1251 = "Windows-1251", UTF16BE = "UTF-16BE", UTF16LE = "UTF-16LE"
 
-  TLineEnding* = enum
+  LineEnding* = enum
     leAuto = "Unknown", leLF = "LF", leCR = "CR", leCRLF = "CRLF"
 
-  THighlightAll* = object
+  HighlightAll* = object
     isHighlighted*: bool
     text*: string # What is currently being highlighted in this tab
     forSearch*: bool # Whether highlightedText is done as a result of a search.
@@ -474,7 +473,7 @@ proc `saved=`*(t: Tab, b: bool) =
   assert(not t.buffer.isNil)
   t.buffer.setModified(not b)
 
-proc detectLineEndings*(text: string): TLineEnding =
+proc detectLineEndings*(text: string): LineEnding =
   var i = 0
   while true:
     case text[i]
@@ -487,14 +486,14 @@ proc detectLineEndings*(text: string): TLineEnding =
       if text[i] == '\0': return leAuto
     i.inc
 
-proc srepr(le: TLineEnding, auto: string): string =
+proc srepr(le: LineEnding, auto: string): string =
   case le
   of leLF: "\L"
   of leCR: "\C"
   of leCRLF: "\c\L"
   of leAuto: auto
 
-proc normalize*(le: TLineEnding, text: string): string =
+proc normalize*(le: LineEnding, text: string): string =
   ## Normalizes newlines and strips trailing whitespace.
   result = ""
   var i = 0
@@ -520,7 +519,7 @@ proc normalize*(le: TLineEnding, text: string): string =
 
     i.inc
 
-proc addExtraNL*(le: TLineEnding, text: var string) =
+proc addExtraNL*(le: LineEnding, text: var string) =
   const defaultLE = "\L"
   let sle = srepr(le, defaultLE)
   if not text.endswith(sle):


### PR DESCRIPTION
Dropped the "T" and "P" prefixes. There are a couple deprecation warning fixes in here that I forgot to commit with the previous pull request as well.