### PR TITLE
Title truncation

### DIFF
--- a/aporia.nim
+++ b/aporia.nim
@@ -844,6 +844,10 @@ proc addTab(name, filename: string, setCurrent: bool = true,
     # Get the name.ext of the filename, for the tabs title
     nam = extractFilename(filename)
 
+  # Truncate title to 20 chars
+  if win.globalSettings.truncateLongTitles:
+    if len(nam) > 20: nam = nam[0..16] & "..."
+
   var (TabLabel, labelText, closeBtn) = createTabLabel(nam, scrollWindow, filename)
 
   # Add a tab

--- a/cfg.nim
+++ b/cfg.nim
@@ -56,6 +56,7 @@ proc defaultGlobalSettings*(): TGlobalSettings =
   result.singleInstance = true
   result.restoreTabs = true
   result.activateErrorTabOnErrors = false
+  result.truncateLongTitles = true
   
   when defined(macosx):
     let mask: guint = MetaMask
@@ -218,6 +219,7 @@ proc save*(settings: TGlobalSettings) =
     f.writeKeyVal("compileUnsavedSave", $settings.compileUnsavedSave)
     f.writeKeyVal("restoreTabs", $settings.restoreTabs)
     f.writeKeyVal("activateErrorTabOnErrors", $settings.activateErrorTabOnErrors)
+    f.writeKeyVal("truncateLongTitles", $settings.truncateLongTitles)
     f.writeKeyValRaw("nimPath", $settings.nimPath)
     f.writeKeyVal("toolBarVisible", $settings.toolBarVisible)
     f.writeKeyVal("wrapMode",
@@ -428,6 +430,7 @@ proc loadGlobal*(cfgErrors: var seq[TError], input: PStream): TGlobalSettings =
         result.singleInstancePort = int32(e.value.parseInt())
       of "restoretabs": result.restoreTabs = isTrue(e.value)
       of "activateerrortabonerrors": result.activateErrorTabOnErrors = isTrue(e.value)
+      of "truncatelongtitles": result.truncateLongTitles = isTrue(e.value)
       of "toolbarvisible": result.toolBarVisible = isTrue(e.value)
       of "compilesaveall": result.compileSaveAll = isTrue(e.value)
       of "nimcmd", "nimrodcmd": result.nimCmd = e.value

--- a/settings.nim
+++ b/settings.nim
@@ -125,6 +125,7 @@ var
   compileSaveAllCheckBox: PCheckButton
   showCloseOnAllTabsCheckBox: PCheckButton
   activateErrorTabOnErrorsCheckBox: PCheckButton
+  truncateLongTitlesCheckbox: PCheckButton
   # Shortcuts:
   keyCommentLinesEdit: PEntry
   keyDeleteLineEdit: PEntry
@@ -402,6 +403,7 @@ proc closeDialog(widget: PWidget, user_data: Pgpointer) =
   win.globalSettings.singleInstance = singleInstanceCheckBox.getActive()
   win.globalSettings.compileSaveAll = compileSaveAllCheckBox.getActive()
   win.globalSettings.activateErrorTabOnErrors = activateErrorTabOnErrorsCheckBox.getActive()
+  win.globalSettings.truncateLongTitles = truncateLongTitlesCheckbox.getActive()
   
   # Shortcuts:
   setShortcutIfValid($keyQuitEdit.getText(), win.globalSettings.keyQuit)
@@ -469,6 +471,9 @@ proc initGeneral(settingsTabs: PNotebook) =
   activateErrorTabOnErrorsCheckBox = addCheckBox(box, "Activate Error list tab on errors", win.globalSettings.activateErrorTabOnErrors)
   
   showCloseOnAllTabsCheckBox = addCheckBox(box, "Show close button on all tabs", win.globalSettings.showCloseOnAllTabs)
+
+  truncateLongTitlesCheckbox = addCheckBox(box, "Truncate long titles", win.globalSettings.truncateLongTitles)
+
   discard showCloseOnAllTabsCheckBox.gSignalConnect("toggled",
     G_CALLBACK(showCloseOnAllTabs_Toggled), nil)
 

--- a/utils.nim
+++ b/utils.nim
@@ -60,7 +60,7 @@ type
     singleInstance*: bool # Whether the program runs as single instance.
     restoreTabs*: bool    # Whether the program loads the tabs from the last session
     activateErrorTabOnErrors*: bool    # Whether the Error list tab will be shown when an error ocurs
-    truncateLongTItles*: bool # Whether to truncate long titles to 20 characters
+    truncateLongTitles*: bool # Whether to truncate long titles to 20 characters
     keyCommentLines*:      ShortcutKey
     keyDeleteLine*:        ShortcutKey
     keyDuplicateLines*:    ShortcutKey

--- a/utils.nim
+++ b/utils.nim
@@ -60,6 +60,7 @@ type
     singleInstance*: bool # Whether the program runs as single instance.
     restoreTabs*: bool    # Whether the program loads the tabs from the last session
     activateErrorTabOnErrors*: bool    # Whether the Error list tab will be shown when an error ocurs
+    truncateLongTItles*: bool # Whether to truncate long titles to 20 characters
     keyCommentLines*:      ShortcutKey
     keyDeleteLine*:        ShortcutKey
     keyDuplicateLines*:    ShortcutKey


### PR DESCRIPTION
Added an option to truncate long tab titles to 20 characters max. Defaults to true.