### PR TITLE
Fix crash when searching for .*

### DIFF
--- a/search.nim
+++ b/search.nim
@@ -113,9 +113,10 @@ proc findRePeg(win: var utils.MainWin, forward: bool, startIter: PTextIter,
     newPattern = styleInsensitive(newPattern)
     isRegex = true  
   
-  # Change .* to . to prevent a crash.
+  # Change .* to prevent a crash.
   if isRegex and newPattern == ".*":
-    newPattern = "."
+    if forward: newPattern = ".*$"
+    else: newPattern = "^.*"
 
   var match = (-1, 0)
   var singleChar = false

--- a/search.nim
+++ b/search.nim
@@ -112,7 +112,11 @@ proc findRePeg(win: var utils.MainWin, forward: bool, startIter: PTextIter,
     reOptions = reOptions + {reIgnoreCase}
     newPattern = styleInsensitive(newPattern)
     isRegex = true  
-    
+  
+  # Change .* to . to prevent a crash.
+  if isRegex and newPattern == ".*":
+    newPattern = "."
+
   var match = (-1, 0)
   var singleChar = false
   if forward:
@@ -128,6 +132,7 @@ proc findRePeg(win: var utils.MainWin, forward: bool, startIter: PTextIter,
         inc(match[1])
         singleChar = true
       newMatch = findBoundsGen($text, newPattern, isRegex, reOptions, match[1])
+      if match[0] == newMatch[1] and match[1] == newMatch[0]: break
       if newMatch != (-1, 0): match = newMatch
       else: break
 


### PR DESCRIPTION
Fixes #95.

There are two parts to this fix:

*  There is a check for when the previous and next matches have flipped fields, as this happens infinitely when dot-star is used.

* dot-star is changed to dot. The previous behavior of dot-star was to get stuck on matching the entire first line, which did not make sense given what the pattern is supposed to match. Changing this pattern to dot results in a more sane match, either the previous or next character.